### PR TITLE
Redis simplification

### DIFF
--- a/bicep/container-apps/container-apps-redis.bicep
+++ b/bicep/container-apps/container-apps-redis.bicep
@@ -2,11 +2,6 @@ param location string = resourceGroup().location
 
 param containerAppsEnvironmentId string
 param containerAppName string
-param imageName string
-param containerRegistryName string
-param containerRegistryConfiguration object
-@secure()
-param containerRegistryPasswordSecret object
 param cpuCores string
 param memory string
 
@@ -17,12 +12,6 @@ resource redisContainerApp 'Microsoft.App/containerApps@2022-10-01' = {
     managedEnvironmentId: containerAppsEnvironmentId
     configuration: {
       activeRevisionsMode: 'Single'
-      secrets: [
-        containerRegistryPasswordSecret
-      ]
-      registries: [
-        containerRegistryConfiguration
-      ]
       ingress: {
         targetPort: 6379
         external: false
@@ -33,8 +22,15 @@ resource redisContainerApp 'Microsoft.App/containerApps@2022-10-01' = {
     template: {
       containers: [
         {
-          name: imageName
-          image: '${containerRegistryName}.azurecr.io/${imageName}:latest'
+          name: 'redis'
+          image: 'docker.io/redis:alpine'
+          command: [
+            'redis-server'
+            '--maxmemory 256mb'
+            '--maxmemory-policy'
+            'volatile-lru'
+            '--save ""'
+          ]
           resources: {
             cpu: json(cpuCores)
             memory: memory

--- a/bicep/container-apps/container-apps.bicep
+++ b/bicep/container-apps/container-apps.bicep
@@ -41,7 +41,6 @@ param supervisordCpuCores string
 param supervisordMemory string
 
 param redisContainerAppName string
-param redisImageName string
 param redisCpuCores string
 param redisMemory string
 
@@ -193,10 +192,6 @@ module redisContainerApp 'container-apps-redis.bicep' = {
     location: location
     containerAppsEnvironmentId: containerAppsEnvironment.outputs.id
     containerAppName: redisContainerAppName
-    imageName: redisImageName
-    containerRegistryPasswordSecret: containerRegistryPasswordSecret
-    containerRegistryConfiguration: containerRegistryConfiguration
-    containerRegistryName: containerRegistryName
     cpuCores: redisCpuCores
     memory: redisMemory
   }

--- a/bicep/container-registry/purge-container-registry-task.sh
+++ b/bicep/container-registry/purge-container-registry-task.sh
@@ -9,9 +9,8 @@ CONTAINER_REGISTRY_NAME=$(jq -r '.parameters.containerRegistryName.value' $1)
 INIT_IMAGE_NAME=$(jq -r '.parameters.initImageName.value // empty' $1)
 PHP_FPM_IMAGE_NAME=$(jq -r '.parameters.phpFpmImageName.value' $1)
 SUPERVISORD_IMAGE_NAME=$(jq -r '.parameters.supervisordImageName.value' $1)
-REDIS_IMAGE_NAME=$(jq -r '.parameters.redisImageName.value' $1)
 
-CONTAINER_REGISTRY_REPOSITORIES=($PHP_FPM_IMAGE_NAME $SUPERVISORD_IMAGE_NAME $REDIS_IMAGE_NAME)
+CONTAINER_REGISTRY_REPOSITORIES=($PHP_FPM_IMAGE_NAME $SUPERVISORD_IMAGE_NAME)
 if [ ! -z "${INIT_IMAGE_NAME}" ];
 then
   CONTAINER_REGISTRY_REPOSITORIES+=($INIT_IMAGE_NAME)

--- a/bicep/container-registry/push-images.sh
+++ b/bicep/container-registry/push-images.sh
@@ -6,9 +6,8 @@ CONTAINER_REGISTRY_NAME=$(jq -r '.parameters.containerRegistryName.value' $1)
 INIT_IMAGE_NAME=$(jq -r '.parameters.initImageName.value // empty' $1)
 PHP_FPM_IMAGE_NAME=$(jq -r '.parameters.phpFpmImageName.value' $1)
 SUPERVISORD_IMAGE_NAME=$(jq -r '.parameters.supervisordImageName.value' $1)
-REDIS_IMAGE_NAME=$(jq -r '.parameters.redisImageName.value' $1)
 
-IMAGES=($PHP_FPM_IMAGE_NAME $SUPERVISORD_IMAGE_NAME $REDIS_IMAGE_NAME)
+IMAGES=($PHP_FPM_IMAGE_NAME $SUPERVISORD_IMAGE_NAME)
 if [ ! -z $INIT_IMAGE_NAME ];
 then
   IMAGES+=($INIT_IMAGE_NAME)
@@ -17,7 +16,7 @@ fi
 EXISTING_REPOSITORIES=$(az acr repository list --name $CONTAINER_REGISTRY_NAME --output tsv)
 if [ -z "$EXISTING_REPOSITORIES" ];
 then
-  # Container Apps require images to actually be present in the Container Registry in order t
+  # Container Apps require images to actually be present in the Container Registry,
   # therefore we tag and push some dummy Hello World ones here.
   echo Pushing Hello World images to Container Registry...
   docker pull hello-world

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -175,17 +175,17 @@ param phpFpmContainerAppName string
 param phpFpmImageName string
 param phpFpmContainerAppUseProbes bool = false
 param phpFpmContainerAppCustomDomains array = []
-param phpFpmCpuCores string = '1.0'
-param phpFpmMemory string = '2Gi'
+param phpFpmCpuCores string = '0.5'
+param phpFpmMemory string = '1Gi'
 param phpFpmScaleToZero bool = false
 param phpFpmMaxReplicas int = 1
 param supervisordContainerAppName string
 param supervisordImageName string
 param supervisordCpuCores string = '0.25'
-param supervisordMemory string = '250Mi'
+param supervisordMemory string = '0.5Gi'
 param redisContainerAppName string
 param redisCpuCores string = '0.25'
-param redisMemory string = '1Gi'
+param redisMemory string = '0.5Gi'
 @allowed(['0', '1'])
 param appDebug string
 param appEnv string

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -184,7 +184,6 @@ param supervisordImageName string
 param supervisordCpuCores string = '0.25'
 param supervisordMemory string = '250Mi'
 param redisContainerAppName string
-param redisImageName string
 param redisCpuCores string = '0.25'
 param redisMemory string = '1Gi'
 @allowed(['0', '1'])
@@ -232,7 +231,6 @@ module containerApps 'container-apps/container-apps.bicep' = {
     pimcoreEnvironment: pimcoreEnvironment
     redisContainerAppName: redisContainerAppName
     redisDb: redisDb
-    redisImageName: redisImageName
     redisSessionDb: redisSessionDb
     redisCpuCores: redisCpuCores
     redisMemory: redisMemory
@@ -327,3 +325,4 @@ param deployImagesToContainerRegistry bool = false //deprecated
 param additionalSecrets object = {}
 param containerRegistrySku string = ''
 param waitForKeyVaultManualIntervention bool = false
+param redisImageName string = '' //deprecated


### PR DESCRIPTION
Removing custom Redis image in favor of the official `:alpine` one for simplicity, and simply using a command override